### PR TITLE
Limit build workflow to development branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Build Krtkus
 
-on: [push, workflow_dispatch]
+on: 
+  push:
+    branches:
+      - development
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Closes #17.
Tento PR se tentokrát mergene do `development`.